### PR TITLE
Fixing the Testing of Cache expiration

### DIFF
--- a/test/Cache.test.js
+++ b/test/Cache.test.js
@@ -4,6 +4,7 @@ var Backbone = require('../src/backbone.khs.js');
 var Cache = Backbone.Cache;
 
 describe('Object Test', function () {
+	
 
     it('Test initialize function is executed', function () {
         spyOn(Cache.prototype, 'initialize');
@@ -21,16 +22,25 @@ describe('Object Test', function () {
     });
 
     it('Add basic item to cache. expire after a set time', function () {
-
-        spyOn(Cache.prototype, 'remove').andCallFake(function() {
-            done();
-        });
+    	jasmine.clock().install();
+        spyOn(Cache.prototype, 'remove').and.callThrough();
 
         var cache = new Cache();
-        console.log(cache);
         cache.put('test', {test:'test'}, {expire: 1000});
-
+        
         expect(cache.store['test']).toBeDefined();
+        expect(Cache.prototype.remove).toHaveBeenCalled();
+        expect(Cache.prototype.remove.calls.count()).toEqual(1);
+        
+        //After 1 second, remove() should be called twice
+        //once in Put(), the other after the expiration of 1 second
+        setTimeout(function() {
+       	 expect(Cache.prototype.remove.calls.count()).toEqual(2);
+       	 expect(cache.store['test']).not.toBeDefined();
+       }, 1000);
+        jasmine.clock().tick(1001);
+      
+        jasmine.clock().uninstall();
     });
 
 });


### PR DESCRIPTION
-Took out the AndCallFake (may not be needed)
-Expected the Remove call to be called twice, once from Put, the other from the expiration
